### PR TITLE
Revert "Update Fastai library"

### DIFF
--- a/MangaQuick.py
+++ b/MangaQuick.py
@@ -8,8 +8,8 @@ import json
 # Third-party library imports
 import streamlit as st
 import torch
-from fastai.vision.all import load_learner #API Update to fastai.vision.all https://forums.fast.ai/t/fastai-v2-upgrade-review-guide-whats-new-in-fastai-version-2/86626
-from fastai.vision.all import *
+from fastai.vision import load_learner
+from fastai.vision import *
 from PIL import Image
 import deepl
 from dotenv import load_dotenv


### PR DESCRIPTION
This reverts commit DCY1117/MangaQuick#4.

Although the pull request proposed updating the import to match the newest version of fastai, it introduced compatibility issues because the rest of the codebase and dependencies are still aligned with an older version. Since no functional changes or dependencies updates were actually made besides the import, and after testing this caused additional problems rather than resolving any, I am reverting this commit.

I did not test the changes in that moment, so my bad. But this issue "Error running in google colab #5" is related to the change made.